### PR TITLE
Ccs 22 jwt token middleware

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -87,7 +87,13 @@ export const login = async (req: Request, res: Response) => {
 
         const token = jwt.sign({ userId: user.id }, JWT_SECRET, { expiresIn: ResponseStrings.KeyExpiry });
 
-        res.json({ message: ResponseStrings.LoginSuccess, token});
+        res.json(
+            { 
+                message: ResponseStrings.LoginSuccess, 
+                token,
+                user: {id: user.id, email: user.email, name: user.firstname}
+            }
+        );
 
     } catch (err){
         res.status(ResponseCodes.InternalServerError).json({ error: ResponseStrings.InternalError })

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "jwt-decode": "^4.0.0",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
+        "@types/jwt-decode": "^2.2.1",
         "@types/node": "^24.0.10",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -1555,6 +1557,13 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/jwt-decode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz",
+      "integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.0.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
@@ -2699,6 +2708,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@tailwindcss/vite": "^4.1.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
+    "@types/jwt-decode": "^2.2.1",
     "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import {
 } from "react-router-dom";
 
 import { AuthProvider } from "./auth/useAuth";
+import AppLayout from "./components/layout/AppLayout";
+import RequireAuth from "./auth/requireAuth";
 
 import Home from "./pages/Home";
 import Login from "./pages/Auth/Login";
@@ -12,20 +14,28 @@ import Signup from "./pages/Auth/Signup";
 import Dashboard from "./pages/Dashboard";
 import ForgotPassword from "./pages/Auth/ForgotPassword";
 
-function App() {
+export default function App() {
   return (
     <AuthProvider>
       <Router>
         <Routes>
-          <Route path="/" element={<Home />} />
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Home />} />
+            <Route
+              path="/dashboard"
+              element={
+                <RequireAuth>
+                  <Dashboard />
+                </RequireAuth>
+              }
+            />
+          </Route>
+
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
-          <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/forgotpassword" element={<ForgotPassword />} />
         </Routes>
       </Router>
     </AuthProvider>
   );
 }
-
-export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,9 @@ import {
   Routes,
   Route,
 } from "react-router-dom";
+
+import { AuthProvider } from "./auth/useAuth";
+
 import Home from "./pages/Home";
 import Login from "./pages/Auth/Login";
 import Signup from "./pages/Auth/Signup";
@@ -11,15 +14,17 @@ import ForgotPassword from "./pages/Auth/ForgotPassword";
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<Signup />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/forgotpassword" element={<ForgotPassword />} />
-      </Routes>
-    </Router>
+    <AuthProvider>
+      <Router>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/forgotpassword" element={<ForgotPassword />} />
+        </Routes>
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/frontend/src/auth/requireAuth.tsx
+++ b/frontend/src/auth/requireAuth.tsx
@@ -1,0 +1,16 @@
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "./useAuth";
+import type React from "react";
+
+export default function RequireAuth({ children }: { children: React.ReactNode }) {
+    const { isAuthed } = useAuth();
+    const location = useLocation();
+
+    if (!isAuthed) {
+        // Redirect them to login, and remember where they tried to go
+        return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+    }
+
+    // Otherwise, render the protected page
+    return children;
+}

--- a/frontend/src/auth/useAuth.tsx
+++ b/frontend/src/auth/useAuth.tsx
@@ -1,0 +1,97 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { jwtDecode } from "jwt-decode"
+
+type JwtPayload = {
+    exp?: number;
+    userId?: number;
+};
+
+export type AuthUser = {
+    id: number;
+    email: string;
+    name: string | null;
+};
+
+// State for our app to check
+type AuthState = {
+    token: string | null;
+    user: AuthUser | null;
+    isAuthed: boolean;
+}
+
+// Extend AuthState with methods
+// Need a way to clear/update token
+type AuthContextValue = AuthState & {
+    frontEndlogin: (token: string, user: AuthUser) => void;
+    frontEndlogout: () => void;
+};
+
+const TOKEN_KEY = "JWT_TOKEN";
+const USER_KEY = "JWT_USER";
+
+// inits a global shared context
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+// ---- Helpers ----
+function isExpired(token: string): boolean {
+    try {
+        const { exp } = jwtDecode<JwtPayload>(token);
+
+        if (!exp) return false;
+
+        const now = Math.floor(Date.now() / 1000);
+        return exp < now;
+
+    } catch {
+        return true;
+    }
+}
+
+function parseStateFromStorage(): AuthState {
+    const token = localStorage.getItem(TOKEN_KEY);
+
+    if (!token || isExpired(token)) {
+        return { token: null, user: null, isAuthed: false };
+    }
+
+    const userRaw = localStorage.getItem(USER_KEY);
+    const user = userRaw ? (JSON.parse(userRaw) as AuthUser) : null;
+
+    return { token, user, isAuthed: true };
+}
+
+// Main function
+
+export function AuthProvider({ children } : { children: React.ReactNode }) {
+
+    const[state, setState] = useState<AuthState>(() => parseStateFromStorage())
+
+    useEffect(() => { 
+        const onStorage = () => setState(parseStateFromStorage()); 
+        window.addEventListener("storage", onStorage); 
+        return () => window.removeEventListener("storage", onStorage); 
+    }, []);
+
+    const frontEndlogin = (token: string, user: AuthUser) => {
+        localStorage.setItem(TOKEN_KEY, token);
+        localStorage.setItem(USER_KEY, JSON.stringify(user));
+        setState({ token, user, isAuthed: true });
+    };
+
+    const frontEndlogout = () => {
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(USER_KEY);
+        setState({ token: null, user: null, isAuthed: false });
+    };
+
+    const value = useMemo(() => ({ ...state, frontEndlogin, frontEndlogout }), [state]);
+
+    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+// ---- Hook ----
+export function useAuth() {
+    const ctx = useContext(AuthContext);
+    if (!ctx) throw new Error("useAuth must be used inside <AuthProvider>");
+    return ctx;
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,0 +1,15 @@
+// Instead of having the header in each file, we can use this file to inject layouts and keep the header here
+
+import { Outlet } from "react-router-dom";
+import Header from "./Header";
+
+export default function AppLayout() {
+    return (
+        <div className="min-h-screen flex flex-col">
+            <Header />
+            <main className="flex1">
+                <Outlet />
+            </main>
+        </div>
+    )
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,65 @@
+import { Link, NavLink, useNavigate } from "react-router-dom";
+import { useAuth } from "@/auth/useAuth";
+import { Button } from "@/components/ui/button"; // if you’re using shadcn buttons; else use <button>
+import LoginStrings from "@/constants/strings/LoginStrings";
+
+// Example nav items
+const nav = [
+  { to: "/", label: "Home" },
+  { to: "/dashboard", label: "Dashboard" },
+];
+
+export default function Header() {
+    const { isAuthed, user, frontEndlogout } = useAuth();
+    const navigate = useNavigate();
+
+    const linkClass = ({ isActive }: { isActive: boolean }) =>
+        `px-2 py-1 rounded-md transition-colors ${
+        isActive ? "text-blue-600 font-semibold" : "text-slate-700 hover:text-blue-600"
+        }`;
+
+    const handleLogout = () => {
+        frontEndlogout();
+        navigate('/');
+    }
+
+    return (
+        <header className="sticky top-0 z-40 w-full bg-white border-b">
+            <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+                <Link to="/" className="text-xl font-bold">
+                Receipt Tracker
+                </Link>
+
+                <nav className="flex items-center gap-6">
+                {nav.map((item) => (
+                    <NavLink key={item.to} to={item.to} className={ linkClass }>
+                    {item.label}
+                    </NavLink>
+                ))}
+                </nav>
+
+                <div className="flex items-center gap-3">
+                {isAuthed ? (
+                    <>
+                    <span className="text-sm text-slate-600">
+                        Hi, {user?.name || user?.email}
+                    </span>
+                    <Button variant="outline" onClick={ handleLogout }>
+                        {LoginStrings.Logout}
+                    </Button>
+                    </>
+                ) : (
+                    <>
+                    <Button variant="outline" asChild>
+                        <Link to="/login">{LoginStrings.LoginButton}</Link>
+                    </Button>
+                    <Button asChild>
+                        <Link to="/signup">{LoginStrings.SignUp}</Link>
+                    </Button>
+                    </>
+                )}
+                </div>
+            </div>
+        </header>
+    );
+}

--- a/frontend/src/constants/strings/LoginStrings.ts
+++ b/frontend/src/constants/strings/LoginStrings.ts
@@ -5,6 +5,7 @@ const LoginStrings = {
   ForgotPassword: "Forgot password?",
   LoginButton: "Login",
   LoggingIn: "Logging in...",
+  Logout: "Logout",
   NotAMember: "Not a member?",
   SignUp: "Sign up",
   EnterEmailOrPassword: "Enter a valid email or password",

--- a/frontend/src/pages/Auth/Login.tsx
+++ b/frontend/src/pages/Auth/Login.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "@/auth/useAuth";
 
 import { Button } from "@/components/ui/button";
 import LoginStrings from "@/constants/strings/LoginStrings";
@@ -21,6 +22,8 @@ export default function Login() {
     const [emailError, setEmailError] = useState<string | null>(null);
     const [passwordError, setPasswordError] = useState<string | null>(null);
 
+    const { frontEndlogin } = useAuth();
+
 
     const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -37,8 +40,8 @@ export default function Login() {
         }
 
         try {
-            const { token } = await login({ email, password });
-            localStorage.setItem("JWT_TOKEN", token);
+            const { token, user } = await login({ email, password });
+            frontEndlogin(token, user);
             navigate("/");
         }
         catch (err) {


### PR DESCRIPTION
Issue:

- Needed a way to store and read the JWT token for authentication purposes. Now we have the ability to check if users are logged in before letting them navigate freely

Implementation:

This is a large commit but it solves a few things. I accidently implemented the header in this commit/issue as well.

- Created a useAuth.tsx file which all children wrapped inside of the Auth wrapped inside of App.tsx can now access login state
- Created the Header component and an injector segment to inject other pages below header instead of having header be added to every single page

Solves:

[CCS-22: JWT Token middleware](https://jachaksekhon.atlassian.net/browse/CCS-22?atlOrigin=eyJpIjoiNDg4MGY4ZjFkODM1NDhkNzg3ODUyMGY2ZmU4OWI0NjUiLCJwIjoiaiJ9)

and

[CCS-33: Create header](https://jachaksekhon.atlassian.net/browse/CCS-33?atlOrigin=eyJpIjoiMzk2MmQxMjVhYTg3NDQzY2EyNTM1MjlhNmUwNmIxZmMiLCJwIjoiaiJ9)